### PR TITLE
Add Reddit comment companion Chrome extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # reddit-comment-companion
+
+## Description
+
+Reddit Comment Companion is a Chrome extension that allows you to view comments for a Reddit post directly on the overview page by hovering over the comment button. This extension is built using Chrome's Manifest V3.
+
+## Installation
+
+1. Clone or download this repository.
+2. Open Chrome and navigate to `chrome://extensions/`.
+3. Enable "Developer mode" by toggling the switch in the top right corner.
+4. Click on the "Load unpacked" button and select the directory where you cloned/downloaded this repository.
+
+## Usage
+
+1. Navigate to Reddit and hover over the comment button below any post to view the comments.
+2. You can also click on the extension icon to open the popup and view comments.
+
+## Contributing
+
+We welcome contributions to the Reddit Comment Companion project. If you have any ideas, suggestions, or bug reports, please open an issue or submit a pull request.
+
+## License
+
+This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/background.js
+++ b/background.js
@@ -1,0 +1,18 @@
+chrome.runtime.onInstalled.addListener(() => {
+  console.log('Extension installed');
+});
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === 'fetchComments') {
+    fetchComments(message.postId).then(comments => {
+      sendResponse({ comments });
+    });
+    return true; // Will respond asynchronously.
+  }
+});
+
+function fetchComments(postId) {
+  return fetch(`https://www.reddit.com/comments/${postId}.json`)
+    .then(response => response.json())
+    .then(data => data[1].data.children.map(child => child.data));
+}

--- a/content.js
+++ b/content.js
@@ -1,0 +1,31 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const commentButtons = document.querySelectorAll('.comment-button');
+
+  commentButtons.forEach(button => {
+    button.addEventListener('mouseover', async () => {
+      const postId = button.getAttribute('data-post-id');
+      const comments = await fetchComments(postId);
+      showComments(button, comments);
+    });
+  });
+});
+
+async function fetchComments(postId) {
+  const response = await fetch(`https://www.reddit.com/comments/${postId}.json`);
+  const data = await response.json();
+  return data[1].data.children.map(child => child.data);
+}
+
+function showComments(button, comments) {
+  const commentsContainer = document.createElement('div');
+  commentsContainer.classList.add('comments-container');
+
+  comments.forEach(comment => {
+    const commentElement = document.createElement('div');
+    commentElement.classList.add('comment');
+    commentElement.textContent = comment.body;
+    commentsContainer.appendChild(commentElement);
+  });
+
+  button.parentElement.appendChild(commentsContainer);
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,27 @@
+{
+  "manifest_version": 3,
+  "name": "Reddit Comment Companion",
+  "version": "1.0",
+  "description": "Show comments for a Reddit post on the overview page by hovering over the comment button.",
+  "permissions": [
+    "activeTab",
+    "storage"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["*://*.reddit.com/*"],
+      "js": ["content.js"]
+    }
+  ],
+  "action": {
+    "default_popup": "popup.html",
+    "default_icon": {
+      "16": "images/icon16.png",
+      "48": "images/icon48.png",
+      "128": "images/icon128.png"
+    }
+  }
+}

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Reddit Comment Companion</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      padding: 10px;
+    }
+    #comments-container {
+      margin-top: 10px;
+    }
+    .comment {
+      border-bottom: 1px solid #ddd;
+      padding: 5px 0;
+    }
+  </style>
+</head>
+<body>
+  <h1>Reddit Comment Companion</h1>
+  <button id="open-comments">Open Comments</button>
+  <div id="comments-container"></div>
+
+  <script>
+    document.getElementById('open-comments').addEventListener('click', () => {
+      chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+        chrome.tabs.sendMessage(tabs[0].id, { type: 'fetchComments' }, (response) => {
+          const commentsContainer = document.getElementById('comments-container');
+          commentsContainer.innerHTML = '';
+          response.comments.forEach(comment => {
+            const commentElement = document.createElement('div');
+            commentElement.classList.add('comment');
+            commentElement.textContent = comment.body;
+            commentsContainer.appendChild(commentElement);
+          });
+        });
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Add a Chrome extension with manifest v3 to show Reddit comments on the overview page.

* **manifest.json**
  - Add necessary configuration for the Chrome extension.
  - Set manifest version to 3.
  - Add permissions for `activeTab` and `storage`.
  - Add background script `background.js`.
  - Add content script `content.js`.

* **background.js**
  - Add listener for the `onInstalled` event.
  - Add listener for the `onMessage` event.
  - Add logic to handle messages from the content script.

* **content.js**
  - Add logic to show comments on the overview page.
  - Add event listener for hovering over the comment button.
  - Add logic to fetch comments from the Reddit API.

* **popup.html**
  - Add basic HTML structure for the popup.
  - Add button to open the comments.
  - Add container to display the comments.

* **README.md**
  - Update description to provide information about the functionality of the extension.
  - Add instructions for installing and using the extension.
  - Add section for contributing to the project.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/timmeinerzhagen/reddit-comment-companion/pull/1?shareId=bd779af4-2cd7-4064-8995-fece714b5310).